### PR TITLE
Allow PluralLocalizationFormatter to accept an IEnumerable argument

### DIFF
--- a/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/PluralLocalizationFormatterTests.cs
@@ -156,6 +156,15 @@ namespace SmartFormat.Tests.Extensions
 			Assert.AreEqual(expectedResult, actualResult);
 		}
 
-
+		[Test]
+		[TestCase("{0:plural:zero|one|many}", new string[0], "zero")]
+		[TestCase("{0:plural:zero|one|many}", new[] { "alice" }, "one")]
+		[TestCase("{0:plural:zero|one|many}", new[] { "alice", "bob" }, "many")]
+		public void Test_should_allow_ienumerable_parameter(string format, object arg0, string expectedResult)
+		{
+			var culture = CultureInfo.CreateSpecificCulture("en-us");
+			var actualResult = Smart.Format(culture, format, arg0);
+			Assert.AreEqual(expectedResult, actualResult);
+		}
 	}
 }


### PR DESCRIPTION
If given, the number of items in the IEnumerable will be used. This allows

``` csharp
Smart.Format("The following {0:plural:person is|people are} impressed: {0:list:{}|, |, and}", people);
```

rather than:

``` csharp
Smart.Format("The following {1:plural:person is|people are} impressed: {0:list:{}|, |, and}", people, people.Count);
```
