### PR TITLE
Treat IEnumerable simillar to IList

### DIFF
--- a/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
+++ b/src/SmartFormat.Tests/Extensions/ListFormatterTests.cs
@@ -132,5 +132,30 @@ namespace SmartFormat.Tests.Extensions
 			var args = GetArgs();
 			Smart.Default.Test(formats, args, expected);
 		}
+
+        [Test]
+        public void EnumerableTest()
+        {
+            var data = new[]{
+				new {
+					Name = "Person A",
+					Gender = "M"
+				},
+				new {
+					Name = "Person B",
+					Gender = "F"
+				},
+				new {
+					Name = "Person C",
+					Gender = "M"
+				}
+		    };
+            var model = new
+            {
+                Persons = data.Where(p => p.Gender == "M")  // Persons's type is System.Linq.Enumerable+WhereArrayIterator`1[<>f__AnonymousType0`2[System.String,System.String]]
+            };
+
+            Assert.That(Smart.Format("{Persons.0.Name}", model), Is.EqualTo("Person A")); 
+        }
 	}
 }

--- a/src/SmartFormat.Tests/SmartFormat.Tests.csproj
+++ b/src/SmartFormat.Tests/SmartFormat.Tests.csproj
@@ -90,6 +90,9 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/SmartFormat/Extensions/ListFormatter.cs
+++ b/src/SmartFormat/Extensions/ListFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Remoting.Messaging;
@@ -59,7 +60,11 @@ namespace SmartFormat.Extensions
 			// See if we're trying to access a specific index:
 			int itemIndex;
 			var currentList = current as IList;
-			var isAbsolute = (selectorInfo.SelectorIndex == 0 && selectorInfo.SelectorOperator.Length == 0);
+            if (currentList == null && current is IEnumerable)
+            {
+                currentList = (current as IEnumerable).Cast<object>().ToList();
+            }
+            var isAbsolute = (selectorInfo.SelectorIndex == 0 && selectorInfo.SelectorOperator.Length == 0);
 			if (!isAbsolute && currentList != null && int.TryParse(selector, out itemIndex) && itemIndex < currentList.Count)
 			{
 				// The current is a List, and the selector is a number;


### PR DESCRIPTION
If the source is IEnumerable treat it as an IList by the ListFormatter.