### PR TITLE
Add support for Dictionary<String, String> in PluralLocalizationFormatter 

### DIFF
--- a/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
+++ b/src/SmartFormat/Extensions/PluralLocalizationFormatter.cs
@@ -11,7 +11,7 @@ namespace SmartFormat.Extensions
 	{
 		private string[] names = { "plural", "p", "" };
 		public string[] Names { get { return names; } set { names = value; } }
-		
+
 		/// <summary>
 		/// Initializes the plugin with rules for many common languages.
 		/// If no CultureInfo is supplied to the formatter, the
@@ -90,6 +90,11 @@ namespace SmartFormat.Extensions
 			var pluralWords = format.Split('|');
 			// This extension requires at least two plural words:
 			if (pluralWords.Count == 1) return false;
+
+            // In order to support dictionary<string,string>()
+            long parsedString;
+            if ((current is string) && (Int64.TryParse(Convert.ToString(current), out parsedString)))
+                current = parsedString;
 
 			// See if the value is a number:
 			var currentIsNumber =


### PR DESCRIPTION
This change adds support for passing to Smart.Format() in combination
with Dictionary (String, String). Previously due to the IsNumber checks
pluralization was not supported.
